### PR TITLE
Disable curl's URL globbing parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ should be using curl directly if your usecase is not covered.
   * Follow redirects;  
   * Automatically chose a filename as output;  
   * Perform retries;  
-  * Resume from broken/interrupted downloads.  
-  * Set the downloaded file timestamp to the value provided by the server, if available;
+  * Resume from broken/interrupted downloads;  
+  * Set the downloaded file timestamp to the value provided by the server, if available;  
+  * Disable **curl**'s URL globbing parser so **{}** and **\[\]** characters in URLs are not treated specially.
 
 <a name="options"></a>
 

--- a/wcurl
+++ b/wcurl
@@ -65,7 +65,7 @@ URLS=""
 CURL_PARALLEL=""
 
 # Parameters to be passed for each URL.
-PER_URL_PARAMETERS="--location --remote-name --remote-time --retry 10 --retry-max-time 10 --continue-at - "
+PER_URL_PARAMETERS="--location --remote-name --remote-time --retry 10 --retry-max-time 10 --continue-at - --globoff "
 
 # Sanitize parameters.
 sanitize() {

--- a/wcurl.1
+++ b/wcurl.1
@@ -30,9 +30,11 @@ By default, \fBwcurl\fR will:
 .br
 \[bu]  Perform retries;
 .br
-\[bu]  Resume from broken/interrupted downloads.
+\[bu]  Resume from broken/interrupted downloads;
 .br
 \[bu]  Set the downloaded file timestamp to the value provided by the server, if available;
+.br
+\[bu]  Disable \fBcurl\fR's URL globbing parser so \fB{}\fR and \fB[]\fR characters in URLs are not treated specially.
 .SH OPTIONS
 .TP
 \fB\-o, \-\-opts=\fI<CURL_OPTIONS>\fR...\fR


### PR DESCRIPTION
Users may not expect URLs that include `[]` and `{}` character pairs to be interpolated by `curl`'s globbing parser when they are expecting the behavior of a simple download tool.  This change adds the "`--globoff`" curl long option to the list of curl options applied by default, to try to provide default behavior that is as unsurprising as possible.

Users who want the globbing behavior still have the option of enabling it with the "`--no-globoff`" curl option, passed in via `wcurl`'s `-o`/`--opts=...` mechanism.